### PR TITLE
Adding clitic lemma and gramm

### DIFF
--- a/uniparser_morph/morph_parser.py
+++ b/uniparser_morph/morph_parser.py
@@ -2,7 +2,7 @@ import re
 import copy
 import time
 from .common_functions import GLOSS_EMPTY, GLOSS_STEM, GLOSS_STEM_FORCED, GLOSS_STARTWITHSELF, POS_NONFINAL
-from .paradigm import Paradigm
+from .paradigm import Paradigm, Inflexion
 from .wordform import Wordform
 from .clitic import SIDE_ENCLITIC, SIDE_PROCLITIC, SIDE_OTHER
 from .morph_fst import MorphFST
@@ -740,12 +740,13 @@ class Parser:
                 elif cl.is_compatible(wf):
                     wf.wf = word
                     # Lemma
-                    wf.add_to_field('lemma', cl.lemma)
-                    # Grammatical tags
-                    wf.add_to_field('gramm', cl.gramm)
+                    wf.add_lemma(cl, Inflexion(self.g, {}))
+                    # Grammatical tags, if present
+                    infl = Inflexion(g=self.g, dictDescr={"name": "flex", "value":"", "content": [{"name": "gramm", "value": cl.gramm}]}, errorHandler=self.errorHandler)
+                    wf.add_gramm(cl, infl)
                     # Additional fields
-                    for field, value in cl.otherData.items():
-                        wf.add_to_field(field, value)
+                    for field, value in cl.otherData:
+                        wf.add_other_data(cl, infl)
                     # Gloss
                     if cl.side == SIDE_PROCLITIC:
                         wf.gloss = cl.gloss + '=' + wf.gloss

--- a/uniparser_morph/wordform.py
+++ b/uniparser_morph/wordform.py
@@ -58,7 +58,10 @@ class Wordform:
 
     def add_lemma(self, lex, flex):
         if flex.lemmaChanger is None:
-            self.lemma = lex.lemma
+            if self.lemma == "":
+                self.lemma = lex.lemma
+            elif lex.lemma != "":
+                self.lemma += ","+lex.lemma
             return
         suitableSubLex = [sl for sl in lex.subLexemes
                           if flex.lemmaChanger.stemNum is None or
@@ -82,7 +85,8 @@ class Wordform:
     def add_gramm(self, sublex, flex):
         self.stem = sublex.stem
         if not flex.replaceGrammar:
-            self.gramm = sublex.gramm
+            if self.gramm == "":
+                self.gramm = sublex.gramm
             if len(sublex.gramm) > 0 and len(flex.gramm) > 0:
                 self.gramm += ','
             self.gramm += flex.gramm


### PR DESCRIPTION
Currently, using clitics.txt lines [743-748](https://github.com/timarkh/uniparser-morph/blob/master/uniparser_morph/morph_parser.py#L743-L748) raise errors like the following:

```
wf.add_to_field('lemma', cl.lemma)
AttributeError: 'Wordform' object has no attribute 'add_to_field'
```

I fixed these uses of `add_to_field` to `add_lemma`, `add_gramm` and `add_other_data`. I also made sure that the `lex` and `gramm` value of clitics are properly added to the word form. If the clitic's `lex` field should not be added to the wordform's lemma, it can be left empty. So if one considers a clitic to be a lexeme of its own, then one can add the lemma, but that is not necessary.

I think this should not break any functionality, but I can of course not be sure :)