### PR TITLE
do_nothing needs an argument

### DIFF
--- a/uniparser_morph/paradigm.py
+++ b/uniparser_morph/paradigm.py
@@ -673,7 +673,7 @@ class InflexionStd(Inflexion):
         }
         return key2func
 
-    def do_nothing(self):
+    def do_nothing(self, obj):
         pass
 
 


### PR DESCRIPTION
`TypeError: do_nothing() takes 1 positional argument but 2 were given`

This bug only occurred with an inflection-specific paradigm link with a `std` field. So:

```
-paradigm: test
 -flex: .se<.>
  gloss: PST
  gramm: pst
  std: .che<.>
 paradigm: p2

-paradigm: p2
 -flex: .li
  gloss: ERG
  gramm: erg
  std: .ri

```
works, but not

```
-paradigm: test
 -flex: .se<.>
  gloss: PST
  gramm: pst
  std: .che<.>
  paradigm: p2

-paradigm: p2
 -flex: .li
  gloss: ERG
  gramm: erg
  std: .ri

```

since `lemma` etc are passed to `do_nothing`, which does not expect an argument. (see also attached MWE: 
[uniparser_mwe_do_nothing.zip](https://github.com/timarkh/uniparser-morph/files/8305212/uniparser_mwe_do_nothing.zip))
